### PR TITLE
Refactor distribution process in GitHub Actions and Justfile

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,4 +57,5 @@ jobs:
 
       - name: Create distribution files.
         run:
-          just upload_assets ${{ needs.setup.outputs.tag }} dist/wildcherry-*.tar.gz
+          just make_distribution_files
+          just upload_assets v${{ needs.setup.outputs.tag }} dist/wildcherry-*.tar.gz

--- a/Justfile
+++ b/Justfile
@@ -42,6 +42,5 @@ make_distribution_files:
         done; \
     done
 
-upload_assets tag: make_distribution_files
+upload_assets tag:
     gh release upload --repo tamada/wildcherry {{ tag }} dist/*.tar.gz
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/tamada/wildcherry/badge.svg?branch=main)](https://coveralls.io/github/tamada/wildcherry?branch=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tamada/wildcherry)](https://goreportcard.com/report/github.com/tamada/wildcherry)
 
-![Version](https://img.shields.io/badge/Version-0.1.3-blue)
+![Version](https://img.shields.io/badge/Version-0.1.4-blue)
 [![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE)
 
 Another implementation of Word Count (`wc`), again.

--- a/cmd/main/version.go
+++ b/cmd/main/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.1.3"
+const VERSION = "0.1.4"


### PR DESCRIPTION
- Updated the publish workflow to include a separate step for creating distribution files before uploading assets.
- Modified the Justfile to clarify the upload_assets recipe, ensuring it runs after make_distribution_files.